### PR TITLE
Make the reconcile timeout configurable

### DIFF
--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -37,6 +37,7 @@ func main() {
 		debug          = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
 		syncInterval   = app.Flag("sync", "Sync interval controls how often all resources will be double checked for drift.").Short('s').Default("1h").Duration()
 		pollInterval   = app.Flag("poll", "Poll interval controls how often an individual resource should be checked for drift.").Default("1m").Duration()
+		timeout        = app.Flag("timeout", "Controls how long Terraform processes may run before they are killed.").Default("20m").Duration()
 		leaderElection = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
 	)
 	kingpin.MustParse(app.Parse(os.Args[1:]))
@@ -64,6 +65,6 @@ func main() {
 
 	rl := ratelimiter.NewDefaultProviderRateLimiter(ratelimiter.DefaultProviderRPS)
 	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add terraform APIs to scheme")
-	kingpin.FatalIfError(controller.Setup(mgr, log, rl, *pollInterval), "Cannot setup terraform controllers")
+	kingpin.FatalIfError(controller.Setup(mgr, log, rl, *pollInterval, *timeout), "Cannot setup terraform controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }

--- a/internal/controller/template.go
+++ b/internal/controller/template.go
@@ -30,8 +30,8 @@ import (
 
 // Setup creates all terraform controllers with the supplied logger and adds
 // them to the supplied manager.
-func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, poll time.Duration) error {
-	if err := workspace.Setup(mgr, l, wl, poll); err != nil {
+func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter, poll, timeout time.Duration) error {
+	if err := workspace.Setup(mgr, l, wl, poll, timeout); err != nil {
 		return err
 	}
 	return config.Setup(mgr, l, wl)

--- a/internal/controller/workspace/workspace.go
+++ b/internal/controller/workspace/workspace.go
@@ -80,7 +80,7 @@ type tfclient interface {
 }
 
 // Setup adds a controller that reconciles Workspace managed resources.
-func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll time.Duration) error {
+func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll, timeout time.Duration) error {
 	name := managed.ControllerName(v1alpha1.WorkspaceGroupKind)
 
 	o := controller.Options{
@@ -93,11 +93,6 @@ func Setup(mgr ctrl.Manager, l logging.Logger, rl workqueue.RateLimiter, poll ti
 		fs:        afero.Afero{Fs: afero.NewOsFs()},
 		terraform: func(dir string) tfclient { return terraform.Harness{Path: tfPath, Dir: dir} },
 	}
-
-	// TODO(negz): Increase this? Terraform operations can block for a long
-	// time. When this timeout is up the terraform process will be sent SIGKILL,
-	// and potentially lose state for any changes that were in progress.
-	timeout := 20 * time.Minute
 
 	r := managed.NewReconciler(mgr,
 		resource.ManagedKind(v1alpha1.WorkspaceGroupVersionKind),

--- a/internal/controller/workspace/workspace.go
+++ b/internal/controller/workspace/workspace.go
@@ -187,8 +187,10 @@ func (c *external) Observe(ctx context.Context, _ resource.Managed) (managed.Ext
 	}
 
 	// TODO(negz): Is there any value in running terraform plan to determine
-	// whether the workspace is up-to-date? Presumably running a no-op apply is
-	// about the same as running a plan.
+	// whether the workspace is up-to-date? Presumably running a no-op apply
+	// is about the same as running a plan. One downside of the current
+	// approach is that we'll emit an event stating that we're updating the
+	// workspace on every reconcile, even if the update is a no-op.
 	return managed.ExternalObservation{
 		ResourceExists:          len(r) > 0,
 		ResourceUpToDate:        false,


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
This probably needs to be tuned in relation to the poll interval at some point; I would imagine that new reconciles that are queued while one is still happening would fail due to the Terraform state lock.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've started the provider with `--timeout=1s` and applied the inline example. I see:

```console
Warning  CannotConnectToProvider  3s (x4 over 7s)    managed/workspace.tf.crossplane.io  cannot initialize Terraform configuration: signal: killed
```

When I bump the timeout to 30 seconds I see reconciles proceeding successfully.