### PR TITLE
Use `terraform plan` to determine whether the workspace is up-to-date 

### DIFF
--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -371,7 +371,7 @@ func (h Harness) Apply(ctx context.Context, o ...Option) error {
 		}
 	}
 
-	args := append([]string{"apply", "-no-color", "-auto-approve"}, ao.args...)
+	args := append([]string{"apply", "-no-color", "-auto-approve", "-input=false"}, ao.args...)
 	cmd := exec.CommandContext(ctx, h.Path, args...) //nolint:gosec
 	cmd.Dir = h.Dir
 
@@ -392,7 +392,7 @@ func (h Harness) Destroy(ctx context.Context, o ...Option) error {
 		}
 	}
 
-	args := append([]string{"destroy", "-no-color", "-auto-approve"}, do.args...)
+	args := append([]string{"destroy", "-no-color", "-auto-approve", "-input=false"}, do.args...)
 	cmd := exec.CommandContext(ctx, h.Path, args...) //nolint:gosec
 	cmd.Dir = h.Dir
 


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Previously we assumed the workspace was not up-to-date during the observe phase and went straight to invoking terraform apply. The rationale was we might as well go straight to trying to apply, because terraform will just abort without making any changes if none are needed. The downside of this approach is that the resource would act as if it were constantly out-of-date, emitting a spurious update event on every reconcile.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've run `terraform_harness_test.go` which is effectively an integration test. I've also tested this out using `examples/workspace-inline.yaml` and confirmed that the provider now only updates workspaces when I actually change them.