### PR TITLE
Grant UID 2000 access to do Terraform things

### DIFF
--- a/cluster/images/provider-terraform-controller/Dockerfile
+++ b/cluster/images/provider-terraform-controller/Dockerfile
@@ -5,9 +5,11 @@ ARG TINI_VERSION
 
 ADD provider /usr/local/bin/crossplane-terraform-provider
 
+# As of Crossplane v1.3.0 provider controllers run as UID 2000.
+# https://github.com/crossplane/crossplane/blob/v1.3.0/internal/controller/pkg/revision/deployment.go#L32
 RUN mkdir /tf
-RUN chown 1001 /tf
+RUN chown 2000 /tf
 
 EXPOSE 8080
-USER 1001
+USER 2000
 ENTRYPOINT ["crossplane-terraform-provider"]


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
As of Crossplane v1.3.0 this is the UID the package manager runs all controllers as, so we need to make sure that user has access to the /tf directory.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9

I've built this image locally and confirmed it can create workdirs under the `/tf` directory when installed by the Crossplane package manager without any special `ControllerConfig`.