### PR TITLE
Fix support for remote modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ metadata:
 spec:
   forProvider:
     # Use any module source supported by terraform init -from-module.
+    source: Remote
     module: https://github.com/crossplane/tf
     # Variables can be specified inline, or loaded from a ConfigMap or Secret.
     vars:

--- a/apis/v1alpha1/workspace_types.go
+++ b/apis/v1alpha1/workspace_types.go
@@ -98,7 +98,6 @@ type WorkspaceParameters struct {
 	Module string `json:"module"`
 
 	// Source of the root module of this workspace.
-	// +kubebuilder:default=Remote
 	Source ModuleSource `json:"source"`
 
 	// Configuration variables.

--- a/examples/workspace-remote.yaml
+++ b/examples/workspace-remote.yaml
@@ -11,6 +11,7 @@ spec:
     # Any module supported by terraform init -from-module, for example a git
     # repository. You can also specify a simple main.tf inline; see
     # workspace-inline.yaml.
+    source: Remote
     module: https://github.com/crossplane/tf
     # Variables can be specified inline.
     vars:

--- a/internal/controller/workspace/workspace_test.go
+++ b/internal/controller/workspace/workspace_test.go
@@ -199,6 +199,11 @@ func TestConnect(t *testing.T) {
 				},
 				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
 				fs:    afero.Afero{Fs: afero.NewMemMapFs()},
+				terraform: func(_ string) tfclient {
+					return &MockTf{
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
+					}
+				},
 			},
 			args: args{
 				mg: &v1alpha1.Workspace{
@@ -233,6 +238,11 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join(tfDir, string(uid), tfCreds): errBoom},
 					},
 				},
+				terraform: func(_ string) tfclient {
+					return &MockTf{
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
+					}
+				},
 			},
 			args: args{
 				mg: &v1alpha1.Workspace{
@@ -265,6 +275,11 @@ func TestConnect(t *testing.T) {
 						errs: map[string]error{filepath.Join(tfDir, string(uid), tfConfig): errBoom},
 					},
 				},
+				terraform: func(_ string) tfclient {
+					return &MockTf{
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
+					}
+				},
 			},
 			args: args{
 				mg: &v1alpha1.Workspace{
@@ -294,6 +309,11 @@ func TestConnect(t *testing.T) {
 						Fs:   afero.NewMemMapFs(),
 						errs: map[string]error{filepath.Join(tfDir, string(uid), tfMain): errBoom},
 					},
+				},
+				terraform: func(_ string) tfclient {
+					return &MockTf{
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
+					}
 				},
 			},
 			args: args{

--- a/package/crds/tf.crossplane.io_workspaces.yaml
+++ b/package/crds/tf.crossplane.io_workspaces.yaml
@@ -48,7 +48,6 @@ spec:
                     description: The root module of this workspace; i.e. the module containing its main.tf file. When the workspace's source is 'Remote' (the default) this can be any address supported by terraform init -from-module, for example a git repository or an S3 bucket. When the workspace's source is 'Inline' the content of a simple main.tf file may be written inline.
                     type: string
                   source:
-                    default: Remote
                     description: Source of the root module of this workspace.
                     enum:
                     - Remote


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
I had not used this functionality in a while; it turns out Terraform refuses to initialize a remote workspace when there are files in place. Unfortunately it also sometimes needs those files. I think we will need a better solution in future - e.g. using go-getter or similar to separately fetch the module.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://git.io/fj2m9
