### PR TITLE
Fix ConfigMap based VarFile population

### DIFF
--- a/internal/controller/workspace/workspace.go
+++ b/internal/controller/workspace/workspace.go
@@ -302,7 +302,7 @@ func (c *external) options(ctx context.Context, p v1alpha1.WorkspaceParameters) 
 			if err := c.kube.Get(ctx, nn, cm); err != nil {
 				return nil, errors.Wrap(err, errVarFile)
 			}
-			o = append(o, terraform.WithVarFile(cm.BinaryData[r.Key], fmt))
+			o = append(o, terraform.WithVarFile([]byte(cm.Data[r.Key]), fmt))
 
 		case v1alpha1.VarFileSourceSecretKey:
 			s := &corev1.Secret{}


### PR DESCRIPTION
* Use Data instead of BinaryData(which is used for non-UTF content
  according to the API spec, see https://pkg.go.dev/k8s.io/api/core/v1#ConfigMap)
  to correctly populated the target varfile
* Fixes #25

Signed-off-by: Yury Tsarev <yury.tsarev@absa.africa>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #25

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
End-to-end tested on the real cluster setup

[contribution process]: https://git.io/fj2m9
