### PR TITLE
Fix root git repository checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 env:
   # Common versions
   GO_VERSION: '1.17'
-  GOLANGCI_VERSION: 'v1.31'
+  GOLANGCI_VERSION: 'v1.45.2'
   DOCKER_BUILDX_VERSION: 'v0.4.2'
 
   # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run

--- a/examples/workspace-inline.yaml
+++ b/examples/workspace-inline.yaml
@@ -17,11 +17,11 @@ spec:
       output "url" {
         value       = google_storage_bucket.example.self_link
       }
-      
+
       resource "random_id" "example" {
         byte_length = 4
       }
-      
+
       // The google provider and remote state are configured by the provider
       // config - see providerconfig.yaml.
       resource "google_storage_bucket" "example" {

--- a/examples/workspace-remote.yaml
+++ b/examples/workspace-remote.yaml
@@ -8,11 +8,14 @@ metadata:
     crossplane.io/external-name: myworkspace
 spec:
   forProvider:
-    # Any module supported by terraform init -from-module, for example a git
-    # repository. You can also specify a simple main.tf inline; see
+    # Git based remote module is supported.
+    # See https://www.terraform.io/language/modules/sources#generic-git-repository
+    # and https://www.terraform.io/language/modules/sources#modules-in-package-sub-directories
+    # for URL structure.
+    # You can also specify a simple main.tf inline; see
     # workspace-inline.yaml.
     source: Remote
-    module: https://github.com/crossplane/tf
+    module: git::https://github.com/crossplane/tf?ref=main
     # Variables can be specified inline.
     vars:
     - key: region
@@ -35,4 +38,4 @@ spec:
   # All Terraform outputs are written to the connection secret.
   writeConnectionSecretToRef:
     namespace: default
-    name: terraform-workspace-example-inline
+    name: terraform-workspace-example-remote

--- a/internal/controller/workspace/workspace.go
+++ b/internal/controller/workspace/workspace.go
@@ -185,6 +185,11 @@ func (c *connector) Connect(ctx context.Context, mg resource.Managed) (managed.E
 			}
 		}
 
+		// Workaround of https://github.com/hashicorp/go-getter/issues/114
+		if err := c.fs.Remove(dir); err != nil {
+			return nil, errors.Wrap(err, errRemoteModule)
+		}
+
 		client := getter.Client{
 			Src: cr.Spec.ForProvider.Module,
 			Dst: dir,


### PR DESCRIPTION
* The git checkout was failing without referencing subdirectory like
  `git::https://example.com/network.git//modules/vpc`

* Fix it by not pre-creating working directory and
  let go-getter do it during intial checkout, otherwise it will fail.

* Update examples

* Fixes #29

Signed-off-by: Yury Tsarev <yury@upbound.io>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #29 

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

e2e workspace checkout with
```
module: git::https://github.com/terraform-aws-modules/terraform-aws-security-group
```

[contribution process]: https://git.io/fj2m9
