### PR TITLE
Cleanup Secret and Lease objects from tfstate

### DIFF
--- a/internal/controller/workspace/workspace.go
+++ b/internal/controller/workspace/workspace.go
@@ -336,7 +336,7 @@ func (c *external) Delete(ctx context.Context, mg resource.Managed) error {
 	ll := &coordv1.LeaseList{}
 	_ = c.kube.List(ctx, ll, client.MatchingLabels(labels))
 	for l := range ll.Items {
-		ls := sl.Items[l]
+		ls := ll.Items[l]
 		_ = c.kube.Delete(ctx, &ls)
 	}
 	return nil

--- a/internal/controller/workspace/workspace_test.go
+++ b/internal/controller/workspace/workspace_test.go
@@ -476,7 +476,7 @@ func TestObserve(t *testing.T) {
 
 	type fields struct {
 		tf   tfclient
-		kube client.Reader
+		kube client.Client
 	}
 
 	type args struct {
@@ -694,7 +694,7 @@ func TestCreate(t *testing.T) {
 
 	type fields struct {
 		tf   tfclient
-		kube client.Reader
+		kube client.Client
 	}
 
 	type args struct {
@@ -888,7 +888,7 @@ func TestDelete(t *testing.T) {
 
 	type fields struct {
 		tf   tfclient
-		kube client.Reader
+		kube client.Client
 	}
 
 	type args struct {
@@ -984,7 +984,9 @@ func TestDelete(t *testing.T) {
 					MockDestroy: func(_ context.Context, _ ...terraform.Option) error { return nil },
 				},
 				kube: &test.MockClient{
-					MockGet: test.NewMockGetFn(nil),
+					MockDelete: test.NewMockDeleteFn(nil),
+					MockGet:    test.NewMockGetFn(nil),
+					MockList:   test.NewMockListFn(nil),
 				},
 			},
 			args: args{


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes

Added code to the Delete method to clean up any Secret or Lease objects that were used by the Terraform
Kubernetes back end to store tfstate information.

Fixes #40 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested in an EKS deployment - verified that deleting a Workspace that is using a Kubernetes backend also deletes the associated Secret and Lease.

[contribution process]: https://git.io/fj2m9
