### PR TITLE
Enable linter to catch errors assignment to blank identifier

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,7 @@ linters-settings:
 
     # report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`;
     # default is false: such cases aren't reported by default.
-    check-blank: false
+    check-blank: true
 
     # [deprecated] comma-separated list of pairs of the form pkg:regex
     # the regex is used to ignore names within pkg. (default "fmt:.*").


### PR DESCRIPTION
Signed-off-by: Yury Tsarev <yury@upbound.io>

<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

This PR enables golint to catch errors assignment to blank identifier

Relates to  review of #52 implementation

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Checked that it is green on the current `main`

```
make lint
11:47:27 [ .. ] verify dependencies have expected content
all modules verified
11:47:28 [ OK ] go modules dependencies verified
11:47:28 [ .. ] golangci-lint
11:47:29 [ OK ] golangci-lint
```

Checked that it is catching the error assignment to blank identifier when it is present in the code


```
11:42:40 [ .. ] golangci-lint
internal/controller/workspace/workspace.go:331:2: Error return value of `c.kube.List` is not checked (errcheck)
	_ = c.kube.List(ctx, sl, client.MatchingLabels(labels))
	^
internal/controller/workspace/workspace.go:334:3: Error return value of `c.kube.Delete` is not checked (errcheck)
		_ = c.kube.Delete(ctx, &sec)
		^
internal/controller/workspace/workspace.go:337:2: Error return value of `c.kube.List` is not checked (errcheck)
	_ = c.kube.List(ctx, ll, client.MatchingLabels(labels))
	^
internal/controller/workspace/workspace.go:340:3: Error return value of `c.kube.Delete` is not checked (errcheck)
		_ = c.kube.Delete(ctx, &ls)
		^
11:42:49 [FAIL]
```