### PR TITLE
Refactor delete handling to remove the workspace

### DIFF
--- a/internal/controller/workspace/workspace_test.go
+++ b/internal/controller/workspace/workspace_test.go
@@ -61,13 +61,14 @@ func (e *ErrFs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, e
 }
 
 type MockTf struct {
-	MockInit      func(ctx context.Context, o ...terraform.InitOption) error
-	MockWorkspace func(ctx context.Context, name string) error
-	MockOutputs   func(ctx context.Context) ([]terraform.Output, error)
-	MockResources func(ctx context.Context) ([]string, error)
-	MockDiff      func(ctx context.Context, o ...terraform.Option) (bool, error)
-	MockApply     func(ctx context.Context, o ...terraform.Option) error
-	MockDestroy   func(ctx context.Context, o ...terraform.Option) error
+	MockInit                   func(ctx context.Context, o ...terraform.InitOption) error
+	MockWorkspace              func(ctx context.Context, name string) error
+	MockOutputs                func(ctx context.Context) ([]terraform.Output, error)
+	MockResources              func(ctx context.Context) ([]string, error)
+	MockDiff                   func(ctx context.Context, o ...terraform.Option) (bool, error)
+	MockApply                  func(ctx context.Context, o ...terraform.Option) error
+	MockDestroy                func(ctx context.Context, o ...terraform.Option) error
+	MockDeleteCurrentWorkspace func(ctx context.Context) error
 }
 
 func (tf *MockTf) Init(ctx context.Context, o ...terraform.InitOption) error {
@@ -96,6 +97,10 @@ func (tf *MockTf) Apply(ctx context.Context, o ...terraform.Option) error {
 
 func (tf *MockTf) Destroy(ctx context.Context, o ...terraform.Option) error {
 	return tf.MockDestroy(ctx, o...)
+}
+
+func (tf *MockTf) DeleteCurrentWorkspace(ctx context.Context) error {
+	return tf.MockDeleteCurrentWorkspace(ctx)
 }
 
 func TestConnect(t *testing.T) {
@@ -476,7 +481,6 @@ func TestConnect(t *testing.T) {
 
 func TestObserve(t *testing.T) {
 	errBoom := errors.New("boom")
-	now := metav1.Now()
 
 	type fields struct {
 		tf   tfclient
@@ -581,50 +585,6 @@ func TestObserve(t *testing.T) {
 			},
 			want: want{
 				err: errors.Wrap(errBoom, errDiff),
-			},
-		},
-		"DiffErrorDeleted": {
-			reason: "We should call the Delete function when an error is encountered while diffing the Terraform configuration on a deleted Workspace",
-			fields: fields{
-				tf: &MockTf{
-					MockDestroy: func(_ context.Context, _ ...terraform.Option) error { return nil },
-					MockDiff:    func(ctx context.Context, o ...terraform.Option) (bool, error) { return false, errBoom },
-				},
-				kube: &test.MockClient{
-					MockDelete: test.NewMockDeleteFn(nil),
-					MockGet:    test.NewMockGetFn(nil),
-					MockList:   test.NewMockListFn(nil),
-				},
-			},
-			args: args{
-				mg: &v1alpha1.Workspace{
-					ObjectMeta: metav1.ObjectMeta{
-						DeletionTimestamp: &now,
-					},
-				},
-			},
-			want: want{
-				o: managed.ExternalObservation{ResourceExists: false},
-			},
-		},
-		"DiffErrorDeletedDestroyError": {
-			reason: "We should raise an error when the Delete function fails after Diff fails on a deleted resource",
-			fields: fields{
-				tf: &MockTf{
-					MockDestroy: func(_ context.Context, _ ...terraform.Option) error { return errBoom },
-					MockDiff:    func(ctx context.Context, o ...terraform.Option) (bool, error) { return false, errBoom },
-				},
-			},
-			args: args{
-				mg: &v1alpha1.Workspace{
-					ObjectMeta: metav1.ObjectMeta{
-						DeletionTimestamp: &now,
-					},
-				},
-			},
-			want: want{
-				o:   managed.ExternalObservation{},
-				err: errors.Wrap(errors.Wrap(errBoom, errDestroy), errDiff),
 			},
 		},
 		"ResourcesError": {
@@ -1039,9 +999,7 @@ func TestDelete(t *testing.T) {
 					MockDestroy: func(_ context.Context, _ ...terraform.Option) error { return nil },
 				},
 				kube: &test.MockClient{
-					MockDelete: test.NewMockDeleteFn(nil),
-					MockGet:    test.NewMockGetFn(nil),
-					MockList:   test.NewMockListFn(nil),
+					MockGet: test.NewMockGetFn(nil),
 				},
 			},
 			args: args{

--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -214,7 +214,7 @@ func (h Harness) DeleteCurrentWorkspace(ctx context.Context) error {
 		// We successfully deleted the workspace; we're done.
 		return nil
 	}
-	// The working directory could be deleted here too instead of waiting for GC to clean it up
+	// TODO(bobh66) The working directory could be deleted here instead of waiting for GC to clean it up
 	return Classify(err)
 }
 


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes
Refactor the delete handling code to use "terraform workspace delete" to remove the workspace cleanly.

Fixes #55 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
The code ran in my local environment for a week with no issues.

[contribution process]: https://git.io/fj2m9
