### PR TITLE
Do not lock state on Diff/Plan

### DIFF
--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -425,7 +425,7 @@ func (h Harness) Diff(ctx context.Context, o ...Option) (bool, error) {
 		}
 	}
 
-	args := append([]string{"plan", "-no-color", "-input=false", "-detailed-exitcode"}, ao.args...)
+	args := append([]string{"plan", "-no-color", "-input=false", "-detailed-exitcode", "-lock=false"}, ao.args...)
 	cmd := exec.CommandContext(ctx, h.Path, args...) //nolint:gosec
 	cmd.Dir = h.Dir
 


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* Apparently read only 'terraform plan' locks the state
* It leads to state locking on every reconciliation loop of the
  specific Workspace
* Avoid locking by '-lock=false' for `plan` only, we are still locking
  on `apply`
* This change is partial mitigation of #46

Related terraform upstream discussions:
* https://github.com/hashicorp/terraform/issues/28130
* https://discuss.hashicorp.com/t/why-does-a-plan-lock-the-state-file/3520/10

Signed-off-by: Yury Tsarev <yury@upbound.io>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
```
$ cat examples/managed-resources/provider-terraform/awsIAMRole.yaml
apiVersion: tf.crossplane.io/v1alpha1
kind: Workspace
metadata:
  name: iamrole-terraform-test
spec:
  forProvider:
    module: git::https://github.com/ytsarev/provider-terraform-test-module.git//iam?ref=main
    source: Remote
    vars:
      - key: iamRole
        value: provider-terraform-test

$ k apply -f examples/managed-resources/provider-terraform/awsIAMRole.yaml

$ k get workspace
NAME                     READY   SYNCED   AGE
iamrole-terraform-test   True    True     104s

$ k -n upbound-system exec -it crossplane-provider-terraform-6f2df84a9c2f-86df6cb4b-jvtsm -- sh # k exec into controller pod

$ Every 2.0s: ps aux                                                                                                                2022-06-16 10:46:57

PID   USER     TIME  COMMAND
    1 2000      0:02 {crossplane-terr} /usr/bin/qemu-x86_64 /usr/local/bin/crossplane-terraform-provider -d
  143 2000      0:00 {sh} /usr/bin/qemu-x86_64 /bin/sh
  160 2000      0:00 {watch} /usr/bin/qemu-x86_64 /bin/watch ps aux
 3080 2000      0:00 {terraform} /usr/bin/qemu-x86_64 /bin/terraform plan -no-color -input=false -detailed-exitcode -lock=false -var=iamRole=provider
 3094 2000      0:04 {terraform} /usr/bin/qemu-x86_64 /bin/terraform plan -no-color -input=false -detailed-exitcode -lock=false -var=iamRole=provider
 3110 2000      0:00 /bin/ps aux

$ k -n upbound-system delete pod crossplane-provider-terraform-6f2df84a9c2f-5d65d747b6-xlsj2 # while terraform plan is running

$ k get workspace # wait for the pod to recover and next reconciliation loop, observe that the Workspace is still healthy, no locking error observed
NAME                     READY   SYNCED   AGE
iamrole-terraform-test   True    True     6m3s

```
[contribution process]: https://git.io/fj2m9
