### PR TITLE
Include outputs in test for ResourceExists  (#71)

### DIFF
--- a/internal/controller/workspace/workspace.go
+++ b/internal/controller/workspace/workspace.go
@@ -286,7 +286,7 @@ func (c *external) Observe(ctx context.Context, mg resource.Managed) (managed.Ex
 	cr.Status.AtProvider = generateWorkspaceObservation(op)
 
 	return managed.ExternalObservation{
-		ResourceExists:          len(r) > 0,
+		ResourceExists:          len(r)+len(op) > 0,
 		ResourceUpToDate:        !differs,
 		ResourceLateInitialized: false,
 		ConnectionDetails:       op2cd(op),


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes
Include outputs in the condition that determines whether the resource exists.

This will handle "calculation only" workspaces that do not create anything but still have outputs.

Fixes #71 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Verified in our testing environment with Workspaces that were previously being "recreated" on every reconciliation

[contribution process]: https://git.io/fj2m9
