### PR TITLE
Make git credentials available to inline and remote (#74)

### DIFF
--- a/internal/controller/workspace/workspace_test.go
+++ b/internal/controller/workspace/workspace_test.go
@@ -304,6 +304,49 @@ func TestConnect(t *testing.T) {
 			},
 			want: errors.Wrap(errBoom, errWriteGitCreds),
 		},
+		"WriteProviderGitCredentialsMkdirError": {
+			reason: "We should return any error encountered while creating the credentials directory in /tmp",
+			fields: fields{
+				kube: &test.MockClient{
+					MockGet: test.NewMockGetFn(nil, func(obj client.Object) error {
+						if pc, ok := obj.(*v1alpha1.ProviderConfig); ok {
+							pc.Spec.Credentials = []v1alpha1.ProviderCredentials{{
+								Filename: ".git-credentials",
+								Source:   xpv1.CredentialsSourceNone,
+							}}
+						}
+						return nil
+					}),
+				},
+				usage: resource.TrackerFn(func(_ context.Context, _ resource.Managed) error { return nil }),
+				fs: afero.Afero{
+					Fs: &ErrFs{
+						Fs:   afero.NewMemMapFs(),
+						errs: map[string]error{filepath.Join("/tmp", tfDir, string(uid)): errBoom},
+					},
+				},
+				terraform: func(_ string) tfclient {
+					return &MockTf{
+						MockInit: func(ctx context.Context, o ...terraform.InitOption) error { return nil },
+					}
+				},
+			},
+			args: args{
+				mg: &v1alpha1.Workspace{
+					ObjectMeta: metav1.ObjectMeta{UID: uid},
+					Spec: v1alpha1.WorkspaceSpec{
+						ResourceSpec: xpv1.ResourceSpec{
+							ProviderConfigReference: &xpv1.Reference{},
+						},
+						ForProvider: v1alpha1.WorkspaceParameters{
+							Module: "github.com/crossplane/rocks",
+							Source: v1alpha1.ModuleSourceRemote,
+						},
+					},
+				},
+			},
+			want: errors.Wrap(errBoom, errWriteGitCreds),
+		},
 		"WriteConfigError": {
 			reason: "We should return any error encountered while writing our crossplane-provider-config.tf file",
 			fields: fields{


### PR DESCRIPTION
Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes
Move the git-credentials env var code out of the Remote module source block so that the GIT_CRED_DIR env variable is available to both inline and remote sources

Fixes #74 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
This has been run in our dev environment and has additional unit test added

[contribution process]: https://git.io/fj2m9
