### PR TITLE
WIP - Catch signals while running terraform commands to allow clean termination

### DIFF
--- a/internal/terraform/terraform.go
+++ b/internal/terraform/terraform.go
@@ -494,6 +494,10 @@ type cmdResult struct {
 
 // runCommand executes the requested command and sends the process SIGTERM if the context finishes before the command
 func runCommand(ctx context.Context, c *exec.Cmd) error {
+	// Do not run terraform command if the provider has been canceled or exceeded the timeout deadline
+	if err := ctx.Err(); err != nil {
+		return errors.Wrap(err, errRunCommand)
+	}
 	ch := make(chan cmdResult, 1)
 	go func() {
 		defer close(ch)


### PR DESCRIPTION
### Description of your changes
Add signal handling when calling terraform commands that lock state so that the command can be gracefully terminated to clean up the workspace state locking.

Fixes #46 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Created a Workspace that has a terraform time_sleep resource with create_timeout set to 5 minutes and uses the terraform kubernetes backend

While tailing the pod log apply the workspace and observe that the reconcile of the workspace starts

Retrieve the list of kubernetes lease resources and observe that there is a lease for the specified workspace

Terminate the provider pod and observe in the logs that the process gets terminated.   Observe that the Lease for the workspace has been deleted.

[contribution process]: https://git.io/fj2m9
