### PR TITLE
Introduce entrypoint to enable working with relative path modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,43 @@ the terraform _apply_ and _destroy_ commands are run with the
 run with the "-no-color", "-input=false", and "-detailed-exitcode" arguments.  Arguments specified in
 applyArgs, destroyArgs and planArgs will be added to these default arguments.
 
+## Custom Entrypoint for Terraform Invocation
+
+In some cases, you might want to initialize and apply terraform in the
+subdirectory of the repository checkout. It is most relevant for the cases when
+your terraform modules contain inline [relative paths](#83).
+
+To enable it, the `Workspace` spec has an **optional** `Entrypoint` field.
+
+Consider this example:
+
+```yml
+apiVersion: tf.crossplane.io/v1alpha1
+kind: Workspace
+metadata:
+  name: relative-path-test
+spec:
+  forProvider:
+    module: git::https://github.com/ytsarev/provider-terraform-test-module.git
+    source: Remote
+    entrypoint: relative-path-iam
+    vars:
+      - key: iamRole
+        value: relative-path-test
+```
+
+In this case, the whole repository will be checked out but terraform will be
+initialized in the `relative-path-iam` subdirectory with the module that
+contains relative path reference to the `iam` module located in the root of the
+tree.
+
+```HCL
+module "relative-path-iam" {
+  source  = "../iam"
+  iamRole = var.iamRole
+}
+```
+
 ## Known limitations:
 
 * You must either use remote state or ensure the provider container's `/tf`

--- a/apis/v1alpha1/workspace_types.go
+++ b/apis/v1alpha1/workspace_types.go
@@ -100,6 +100,11 @@ type WorkspaceParameters struct {
 	// Source of the root module of this workspace.
 	Source ModuleSource `json:"source"`
 
+	// Entrypoint for `terraform init` within the module
+	// +kubebuilder:default=""
+	// +optional
+	Entrypoint string `json:"entrypoint"`
+
 	// Configuration variables.
 	// +optional
 	Vars []Var `json:"vars,omitempty"`

--- a/package/crds/tf.crossplane.io_workspaces.yaml
+++ b/package/crds/tf.crossplane.io_workspaces.yaml
@@ -70,6 +70,10 @@ spec:
                     items:
                       type: string
                     type: array
+                  entrypoint:
+                    default: ""
+                    description: Entrypoint for `terraform init` within the module
+                    type: string
                   initArgs:
                     description: Arguments to be included in the terraform init CLI
                       command


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Fixes #83

Signed-off-by: Yury Tsarev <yury@upbound.io>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Used https://github.com/ytsarev/provider-terraform-test-module for e2e testing

```
$ cat tf.yaml
apiVersion: tf.crossplane.io/v1alpha1
kind: Workspace
metadata:
  name: relative-path-test
spec:
  forProvider:
    module: git::https://github.com/ytsarev/provider-terraform-test-module.git
    source: Remote
    entrypoint: relative-path-iam
    vars:
      - key: iamRole
        value: relative-path-test

$ cat tf-regression.yaml
apiVersion: tf.crossplane.io/v1alpha1
kind: Workspace
metadata:
  name: regression-test
spec:
  forProvider:
    module: git::https://github.com/ytsarev/provider-terraform-test-module.git//iam?ref=main
    source: Remote
    vars:
      - key: iamRole
        value: regression-test

k apply -f tf.yaml

k apply -f tf-regression.yaml

k get -f tf-regression.yaml
NAME              READY   SYNCED   AGE
regression-test   True    True     4m52s

k get -f tf.yaml
NAME                 READY   SYNCED   AGE
relative-path-test   True    True     4m52s
```



[contribution process]: https://git.io/fj2m9
