### PR TITLE
Example of observe-only workaround experiment

### DIFF
--- a/examples/observe-only-composition/README.md
+++ b/examples/observe-only-composition/README.md
@@ -1,0 +1,16 @@
+# Workaround for Observe-Only Resources Functionality
+
+This example Configuration(Composition+XRD) demonstrates a temporary workaround
+for Observe-Only Resources functionality before it is [properly
+implemented](https://github.com/crossplane/crossplane/issues/1722)
+the core Crossplane.
+
+The workaround consists of a `Composition` that provides a mix of provider-terraform
+`Workspace` with the
+[aws_vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc)
+**data** resource as Inline module.
+
+It publishes the discovered observe-only `vpcId` to the `XSubnet` XR status.
+
+The `vpcId` from the status is getting eventually consumed by the native `Subnet`
+provider-aws resource which is a part of the same `Composition`.

--- a/examples/observe-only-composition/composition.yaml
+++ b/examples/observe-only-composition/composition.yaml
@@ -1,0 +1,57 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xsubnets.aws.platformref.upbound.io
+  labels:
+    provider: aws
+spec:
+  compositeTypeRef:
+    apiVersion: aws.platformref.upbound.io/v1alpha1
+    kind: XSubnet
+  resources:
+    - name: observe-only-vpc
+      base:
+        apiVersion: tf.crossplane.io/v1alpha1
+        kind: Workspace
+        metadata:
+          name: observe-only-vpc
+        spec:
+          forProvider:
+            source: Inline
+            module: |
+              data "aws_vpc" "observe_only" {
+                tags = {
+                  Name = var.vpcName
+                }
+              }
+              output "vpc_id" {
+                description = "Observe Only VPC ID"
+                value       = try(data.aws_vpc.observe_only.id, "")
+              }
+              variable "vpcName" {
+                description = "VPC name"
+                type        = string
+              }
+            vars:
+              - key: vpcName
+      patches:
+        - fromFieldPath: spec.vpcName
+          toFieldPath: spec.forProvider.vars[0].value
+        - type: ToCompositeFieldPath
+          fromFieldPath: status.atProvider.outputs.vpc_id
+          toFieldPath: status.share.vpcId
+          policy:
+            fromFieldPath: Optional
+    - name: subnet
+      base:
+        apiVersion: ec2.aws.upbound.io/v1beta1
+        kind: Subnet
+        spec:
+          forProvider:
+            region: eu-central-1
+            cidrBlock: 10.0.0.0/25
+      patches:
+        - fromFieldPath: status.share.vpcId
+          toFieldPath: spec.forProvider.vpcId
+          policy:
+            fromFieldPath: Required

--- a/examples/observe-only-composition/definition.yaml
+++ b/examples/observe-only-composition/definition.yaml
@@ -1,0 +1,32 @@
+apiVersion: apiextensions.crossplane.io/v1
+kind: CompositeResourceDefinition
+metadata:
+  name: xsubnets.aws.platformref.upbound.io
+spec:
+  group: aws.platformref.upbound.io
+  names:
+    kind: XSubnet
+    plural: xsubnets
+  versions:
+  - name: v1alpha1
+    served: true
+    referenceable: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        properties:
+          spec:
+            type: object
+            properties:
+              vpcName:
+                type: string
+            required:
+            - vpcName
+          status:
+            description: A Status represents the observed state
+            properties:
+              share:
+                description: Freeform field containing status information
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+            type: object

--- a/examples/observe-only-composition/xsubnet.yaml
+++ b/examples/observe-only-composition/xsubnet.yaml
@@ -1,0 +1,6 @@
+apiVersion: aws.platformref.upbound.io/v1alpha1
+kind: XSubnet
+metadata:
+  name: subnet-with-observe-only-vpc
+spec:
+  vpcName: observeonly


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Provides a temporary solution to the observe-only problem using provider-terraform.

Signed-off-by: Yury Tsarev <yury@upbound.io>
<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Crossplane issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":

-->
Relates to https://github.com/crossplane/crossplane/issues/1722

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
```
k apply -f xsubnet.yaml

k get xsubnets.aws.platformref.upbound.io
NAME                           READY   COMPOSITION                           AGE
subnet-with-observe-only-vpc   True    xsubnets.aws.platformref.upbound.io   29m

k get workspace
NAME                                 READY   SYNCED   AGE
subnet-with-observe-only-vpc-x6cfr   True    True     29m

k get subnet.ec2.aws
NAME                                 READY   SYNCED   EXTERNAL-NAME              AGE
subnet-with-observe-only-vpc-rprxx   True    True     subnet-064b90776eafffcfe   24m
```
[contribution process]: https://git.io/fj2m9
