### PR TITLE
Add categories to provider CRDs

### DIFF
--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -58,7 +58,7 @@ type ProviderConfigStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentials.secretRef.name",priority=1
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,terraform}
 type ProviderConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
@@ -83,7 +83,7 @@ type ProviderConfigList struct {
 // +kubebuilder:printcolumn:name="CONFIG-NAME",type="string",JSONPath=".providerConfigRef.name"
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,terraform}
 type ProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha1/workspace_types.go
+++ b/apis/v1alpha1/workspace_types.go
@@ -151,7 +151,7 @@ type WorkspaceStatus struct {
 // +kubebuilder:printcolumn:name="READY",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="SYNCED",type="string",JSONPath=".status.conditions[?(@.type=='Synced')].status"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,terraform}
 type Workspace struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/package/crds/tf.crossplane.io_providerconfigs.yaml
+++ b/package/crds/tf.crossplane.io_providerconfigs.yaml
@@ -9,6 +9,10 @@ metadata:
 spec:
   group: tf.crossplane.io
   names:
+    categories:
+    - crossplane
+    - provider
+    - terraform
     kind: ProviderConfig
     listKind: ProviderConfigList
     plural: providerconfigs

--- a/package/crds/tf.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/tf.crossplane.io_providerconfigusages.yaml
@@ -9,6 +9,10 @@ metadata:
 spec:
   group: tf.crossplane.io
   names:
+    categories:
+    - crossplane
+    - provider
+    - terraform
     kind: ProviderConfigUsage
     listKind: ProviderConfigUsageList
     plural: providerconfigusages

--- a/package/crds/tf.crossplane.io_workspaces.yaml
+++ b/package/crds/tf.crossplane.io_workspaces.yaml
@@ -9,6 +9,10 @@ metadata:
 spec:
   group: tf.crossplane.io
   names:
+    categories:
+    - crossplane
+    - managed
+    - terraform
     kind: Workspace
     listKind: WorkspaceList
     plural: workspaces


### PR DESCRIPTION


<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

Include provider CRDs into the relevant API categories. 

Fixes #114

Enables getting Workspaces in the output of `kubectl get managed` and `kubectl get terraform`

Similar changes to `ProviderConfig` and `ProviderConfigUsage` for getting into `kubectl get provider` and `kubectl get terraform` output

Signed-off-by: Yury Tsarev <yury@upbound.io>


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

```console
k apply -f examples/workspace-remote.yaml
workspace.tf.crossplane.io/example-remote configured

k get managed
NAME                                        READY   SYNCED   AGE
workspace.tf.crossplane.io/example-remote           False    5m21s

k get terraform
NAME                                                                        AGE     CONFIG-NAME   RESOURCE-KIND   RESOURCE-NAME
providerconfigusage.tf.crossplane.io/44d34bbb-c4e0-49c9-a7ec-27e496ed75a9   5m29s   default       Workspace       example-remote

NAME                                        READY   SYNCED   AGE
workspace.tf.crossplane.io/example-remote           False    5m29s

NAME                                      AGE
providerconfig.tf.crossplane.io/default   14m


k get provider
NAME                                                                        AGE     CONFIG-NAME   RESOURCE-KIND   RESOURCE-NAME
providerconfigusage.tf.crossplane.io/44d34bbb-c4e0-49c9-a7ec-27e496ed75a9   5m38s   default       Workspace       example-remote

NAME                                      AGE
providerconfig.tf.crossplane.io/default   14m
```

[contribution process]: https://git.io/fj2m9
