### PR TITLE
Fix `make run` for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ cover.out
 
 # ignore asdf local versions
 /.tool-versions
+
+# local tf dir
+/tf

--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,9 @@ build.init: $(UP)
 run: go.build
 	@$(INFO) Running Crossplane locally out-of-cluster . . .
 	@# To see other arguments that can be provided, run the command with --help instead
-	$(GO_OUT_DIR)/$(PROJECT_NAME) --debug
+	@# KUBE_CONFIG_PATH explained at  https://developer.hashicorp.com/terraform/language/settings/backends/kubernetes
+	@# XP_TF_DIR is to override default tf work dir which is usually /tf and unreadable locally
+	KUBE_CONFIG_PATH=~/.kube/config XP_TF_DIR=./tf $(GO_OUT_DIR)/provider --debug
 
 dev: $(KIND) $(KUBECTL)
 	@$(INFO) Creating kind cluster

--- a/cluster/images/provider-terraform/Dockerfile
+++ b/cluster/images/provider-terraform/Dockerfile
@@ -14,7 +14,7 @@ RUN cd /tmp \
   && unzip /tmp/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip -d /usr/local/bin \
   && chmod +x /usr/local/bin/terraform \
   && rm /tmp/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip
-  
+
 # As of Crossplane v1.3.0 provider controllers run as UID 2000.
 # https://github.com/crossplane/crossplane/blob/v1.3.0/internal/controller/pkg/revision/deployment.go#L32
 RUN mkdir /tf


### PR DESCRIPTION
<!--
Thank you for helping to improve Crossplane!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

* Fix `make run` failing target
* Introduce `XP_TF_DIR` env variable to control main `tfDir` location
* Use `KUBE_CONFIG_PATH` from https://developer.hashicorp.com/terraform/language/settings/backends/kubernetes to handle local out-of-cluster controller execution

Signed-off-by: Yury Tsarev <yury@upbound.io>

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

Assuming following `default` `ProviderConfig`

```
k get providerconfig.tf default -o yaml | k neat
apiVersion: tf.crossplane.io/v1alpha1
kind: ProviderConfig
metadata:
  name: default
spec:
  configuration: |
    terraform {
      backend "kubernetes" {
        secret_suffix     = "providerconfig-terraform-aws"
        namespace         = "upbound-system"
        #in_cluster_config = true
      }
    }
    provider "aws" {
      shared_credentials_file = "aws-creds.ini"
      region = "eu-central-1"
    }
  credentials:
  - filename: .git-credentials
    secretRef:
      key: .git-credentials
      name: git-credentials
      namespace: upbound-system
    source: Secret
  - filename: aws-creds.ini
    secretRef:
      key: credentials
      name: aws-creds
      namespace: upbound-system
    source: Secret
  pluginCache: true
```

```
$ make run
 make run
12:33:58 [ .. ] go build linux_arm64
github.com/crossplane-contrib/provider-terraform/cmd/provider
12:33:59 [ OK ] go build linux_arm64
12:33:59 [ .. ] Running Crossplane locally out-of-cluster . . .
KUBE_CONFIG_PATH=~/.kube/config XP_TF_DIR=./tf /Users/xnull/upstream/provider-terraform/_output/bin/darwin_arm64/provider --debug
2022-11-05T12:34:00.044+0100	DEBUG	provider-terraform	Starting	{"sync-period": "1h0m0s"}
I1105 12:34:01.246465   33153 request.go:682] Waited for 1.189690708s due to client-side throttling, not priority and fairness, request: GET:https://0.0.0.0:61154/apis/policy/v1?timeout=32s
I1105 12:34:11.246390   33153 request.go:682] Waited for 11.190032833s due to client-side throttling, not priority and fairness, request: GET:https://0.0.0.0:61154/apis/gcp.platformref.upbound.io/v1alpha1?timeout=32s
2022-11-05T12:34:14.850+0100	INFO	controller-runtime.metrics	Metrics server is starting to listen	{"addr": ":8080"}
2022-11-05T12:34:14.852+0100	INFO	Starting server	{"path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
2022-11-05T12:34:14.852+0100	INFO	Starting EventSource	{"controller": "providerconfig/providerconfig.tf.crossplane.io", "controllerGroup": "tf.crossplane.io", "controllerKind": "ProviderConfig", "source": "kind source: *v1alpha1.ProviderConfig"}
2022-11-05T12:34:14.852+0100	INFO	Starting EventSource	{"controller": "providerconfig/providerconfig.tf.crossplane.io", "controllerGroup": "tf.crossplane.io", "controllerKind": "ProviderConfig", "source": "kind source: *v1alpha1.ProviderConfigUsage"}
2022-11-05T12:34:14.852+0100	INFO	Starting EventSource	{"controller": "managed/workspace.tf.crossplane.io", "controllerGroup": "tf.crossplane.io", "controllerKind": "Workspace", "source": "kind source: *v1alpha1.Workspace"}
2022-11-05T12:34:14.852+0100	INFO	Starting Controller	{"controller": "managed/workspace.tf.crossplane.io", "controllerGroup": "tf.crossplane.io", "controllerKind": "Workspace"}
2022-11-05T12:34:14.852+0100	INFO	Starting Controller	{"controller": "providerconfig/providerconfig.tf.crossplane.io", "controllerGroup": "tf.crossplane.io", "controllerKind": "ProviderConfig"}
2022-11-05T12:34:14.953+0100	INFO	Starting workers	{"controller": "managed/workspace.tf.crossplane.io", "controllerGroup": "tf.crossplane.io", "controllerKind": "Workspace", "worker count": 1}
2022-11-05T12:34:14.953+0100	INFO	Starting workers	{"controller": "providerconfig/providerconfig.tf.crossplane.io", "controllerGroup": "tf.crossplane.io", "controllerKind": "ProviderConfig", "worker count": 1}
2022-11-05T12:34:14.954+0100	DEBUG	provider-terraform	Reconciling	{"controller": "managed/workspace.tf.crossplane.io", "request": "/iamrole-terraform-test3"}
2022-11-05T12:34:14.954+0100	DEBUG	provider-terraform	Reconciling	{"controller": "providerconfig/providerconfig.tf.crossplane.io", "request": "/default"}
2022-11-05T12:34:14.966+0100	DEBUG	provider-terraform	Reconciling	{"controller": "providerconfig/providerconfig.tf.crossplane.io", "request": "/default"}
2022-11-05T12:34:20.012+0100	DEBUG	provider-terraform	External resource is up to date	{"controller": "managed/workspace.tf.crossplane.io", "request": "/iamrole-terraform-test3", "uid": "f2cb4cf9-0ebe-4762-a8a3-9cde1d6b4ce1", "version": "5508284", "external-name": "iamrole-terraform-test3", "requeue-after": "2022-11-05T12:35:20.012+0100"}
2022-11-05T12:34:20.020+0100	DEBUG	provider-terraform	Reconciling	{"controller": "managed/workspace.tf.crossplane.io", "request": "/iamrole-terraform-test2"}
2022-11-05T12:34:24.427+0100	DEBUG	provider-terraform	External resource is up to date	{"controller": "managed/workspace.tf.crossplane.io", "request": "/iamrole-terraform-test2", "uid": "09c54e2d-5fdf-482b-ab22-b5228df2a98c", "version": "5503191", "external-name": "iamrole-terraform-test2", "requeue-after": "2022-11-05T12:35:24.427+0100"}
```

It is visible in the output that `Workspace` resource is getting properly reconciled locally.

[contribution process]: https://git.io/fj2m9
