### PR TITLE
Fix make when behind http proxy

### DIFF
--- a/cluster/images/provider-terraform/Dockerfile
+++ b/cluster/images/provider-terraform/Dockerfile
@@ -1,6 +1,5 @@
 FROM alpine:3.16.2
-RUN apk --no-cache add ca-certificates bash git
-
+RUN apk --no-cache add ca-certificates bash git curl
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -9,12 +8,9 @@ ENV TERRAFORM_VERSION=1.3.4
 ADD "bin/${TARGETOS}_${TARGETARCH}/provider" /usr/local/bin/crossplane-terraform-provider
 ADD .gitconfig .gitconfig
 
-RUN cd /tmp \
-  && wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip \
-  && unzip /tmp/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip -d /usr/local/bin \
-  && chmod +x /usr/local/bin/terraform \
-  && rm /tmp/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip
-
+RUN curl -s -L https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip | \
+  unzip -d /usr/local/bin - \
+  && chmod +x /usr/local/bin/terraform
 # As of Crossplane v1.3.0 provider controllers run as UID 2000.
 # https://github.com/crossplane/crossplane/blob/v1.3.0/internal/controller/pkg/revision/deployment.go#L32
 RUN mkdir /tf

--- a/cluster/images/provider-terraform/Makefile
+++ b/cluster/images/provider-terraform/Makefile
@@ -12,8 +12,8 @@ include ../../../build/makelib/imagelight.mk
 # Targets
 
 img.build:
-	@$(INFO) docker build $(IMAGE)
-	@$(MAKE) BUILD_ARGS="--load" img.build.shared
+	@$(INFO) docker build $(BUILD_ARGS) $(IMAGE)
+	@$(MAKE) BUILD_ARGS="$(BUILD_ARGS) --load" img.build.shared
 	@$(OK) docker build $(IMAGE)
 
 img.publish:


### PR DESCRIPTION
* Update to latest build submodule
* Use curl instead of wget to retrieve image
* Allow BUILD_ARGS from environment to support proxy variables

Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes
Updated the Dockerfile to install curl and use it in place of wget - curl works with
the http_proxy and https_proxy environment variables

Updated the Makefile to allow external BUILD_ARGS to be passed in so that the env variables can be passed
into the docker build command without modifying the Dockerfile

For example:   make BUILD_ARGS="--build-arg http_proxy=http://my.proxy.com --build-arg https_proxy=http://my.proxy.com"

Fixes #130 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Generated an image and running it in our development environment

[contribution process]: https://git.io/fj2m9
