### PR TITLE
Refactor plugin cache implementation

### DIFF
--- a/cluster/images/provider-terraform/Dockerfile
+++ b/cluster/images/provider-terraform/Dockerfile
@@ -4,17 +4,19 @@ ARG TARGETOS
 ARG TARGETARCH
 
 ENV TERRAFORM_VERSION=1.3.4
+ENV TF_IN_AUTOMATION=1
+ENV TF_PLUGIN_CACHE_DIR=/tf/plugin-cache
 
 ADD "bin/${TARGETOS}_${TARGETARCH}/provider" /usr/local/bin/crossplane-terraform-provider
 ADD .gitconfig .gitconfig
 
 RUN curl -s -L https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${TARGETOS}_${TARGETARCH}.zip | \
   unzip -d /usr/local/bin - \
-  && chmod +x /usr/local/bin/terraform
+  && chmod +x /usr/local/bin/terraform \
+  && mkdir -p ${TF_PLUGIN_CACHE_DIR} \
+  && chown -R 2000 /tf
 # As of Crossplane v1.3.0 provider controllers run as UID 2000.
 # https://github.com/crossplane/crossplane/blob/v1.3.0/internal/controller/pkg/revision/deployment.go#L32
-RUN mkdir /tf
-RUN chown 2000 /tf
 
 USER 65532
 ENTRYPOINT ["crossplane-terraform-provider"]


### PR DESCRIPTION
* Remove setenv of TF_PLUGIN_CACHE_DIR for each Workspace connect
* Set TF_PLUGIN_CACHE_DIR env var in Dockerfile
* Unset TF_PLUGIN_CACHE_DIR in the CLI process environment when pluginCache is false
* Set TF_IN_AUTOMATION env var in Dockerfile

Signed-off-by: Bob Haddleton <bob.haddleton@nokia.com>

### Description of your changes

Fixes #139 

I have:

- [X] Read and followed Crossplane's [contribution process].
- [X] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested
Tested in a development cluster with 100+ workspaces

[contribution process]: https://git.io/fj2m9
