### PR TITLE
Bump Terraform CLI to v1.5.7

### DIFF
--- a/cluster/images/provider-terraform/Dockerfile
+++ b/cluster/images/provider-terraform/Dockerfile
@@ -3,7 +3,7 @@ RUN apk --no-cache add ca-certificates bash git curl
 ARG TARGETOS
 ARG TARGETARCH
 
-ENV TERRAFORM_VERSION=1.5.5
+ENV TERRAFORM_VERSION=1.5.7
 ENV TF_IN_AUTOMATION=1
 ENV TF_PLUGIN_CACHE_DIR=/tf/plugin-cache
 


### PR DESCRIPTION
<!--
Please read through https://git.io/fj2m9 if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #260 

We've prepared the [release for v1.5.7](https://github.com/upbound/terraform/releases/tag/v1.5.7) in response to #260, and this PR bumps the TF CLI to `v1.5.7`, reflecting https://github.com/hashicorp/terraform/releases/tag/v1.5.7.

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Locally built the provider image and ran:
```shell
> which terraform
/usr/local/bin/terraform

> terraform --version
Terraform v1.5.7
on linux_arm64
```

[contribution process]: https://git.io/fj2m9
